### PR TITLE
Upgrade GPflow past version 2.6.0

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install gpflow==2.6.0 numpy pandas==1.5.3 pylint rpy2==3.4.5 scipy statsmodels
+          pip install gpflow==2.6.1 numpy pandas==1.5.3 pylint rpy2==3.4.5 scipy statsmodels
       - name: Analysing the code with pylint
         run: |
           pylint $(git ls-files '*.py') --disable=line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring --fail-under=7

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install gpflow==2.6.1 numpy pandas==1.5.3 pylint rpy2==3.4.5 scipy statsmodels
+          pip install gpflow>=2.6.0 numpy pandas==1.5.3 pylint rpy2==3.4.5 scipy statsmodels
       - name: Analysing the code with pylint
         run: |
           pylint $(git ls-files '*.py') --disable=line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring --fail-under=7

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install gpflow==2.5.2 numpy pandas pylint rpy2==3.4.5 scipy statsmodels
+          pip install gpflow==2.6.0 numpy pandas==1.5.3 pylint rpy2==3.4.5 scipy statsmodels
       - name: Analysing the code with pylint
         run: |
           pylint $(git ls-files '*.py') --disable=line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring --fail-under=7

--- a/fcest/helpers/__init__.py
+++ b/fcest/helpers/__init__.py
@@ -1,7 +1,7 @@
 from .array_operations import are_all_positive_definite, convert_tensor_to_correlation, to_correlation_structure, zscore_estimates
 from .data import to_2d_format, to_3d_format, test_for_normality
 from .filtering import highpass_filter_data
-from .inference import run_adam_vwp, run_adam_svwp
+from .inference import run_adam
 from .summary_measures import summarize_tvfc_estimates, fit_and_extract_ar1_param, compute_rate_of_change, _rate_of_change
 
 __all__ = [
@@ -15,8 +15,7 @@ __all__ = [
     "to_3d_format",
     "test_for_normality",
     "highpass_filter_data",
-    "run_adam_vwp",
-    "run_adam_svwp",
+    "run_adam",
     "summarize_tvfc_estimates",
     "fit_and_extract_ar1_param",
     "compute_rate_of_change",

--- a/fcest/helpers/array_operations.py
+++ b/fcest/helpers/array_operations.py
@@ -94,18 +94,18 @@ def zscore_estimates(tvfc_estimates_array: np.array) -> np.array:
     return tvfc_estimates_array - np.mean(tvfc_estimates_array) / np.std(tvfc_estimates_array)
 
 
-def get_all_lower_triangular_indices_tuples(n_time_series: int) -> list:
+def get_all_lower_triangular_indices_tuples(num_time_series: int) -> list:
     """
     Returns a list of tuples, where each tuple contains the indices of one of the lower
     triangular elements of a matrix.
 
     Parameters
     ----------
-    :param n_time_series:
+    :param num_time_series:
     :return:
     """
     return list(
-        zip(*np.tril_indices(n_time_series, k=-1))
+        zip(*np.tril_indices(num_time_series, k=-1))
     )
 
 

--- a/fcest/helpers/data.py
+++ b/fcest/helpers/data.py
@@ -27,11 +27,11 @@ def to_3d_format(r_formatted_array: np.array) -> np.array:
     :param r_formatted_array: array of shape (D*D, N).
     :return: array of shape (N, D, D).
     """
-    n_time_series = int(np.sqrt(r_formatted_array.shape[0]))
+    num_time_series = int(np.sqrt(r_formatted_array.shape[0]))
     assert len(r_formatted_array.shape) == 2
     three_dimensional_cov_matrices_array = np.reshape(
         r_formatted_array,
-        (n_time_series, n_time_series, r_formatted_array.shape[1])
+        (num_time_series, num_time_series, r_formatted_array.shape[1])
     )
     three_dimensional_cov_matrices_array = np.transpose(three_dimensional_cov_matrices_array, (2, 1, 0))
     return three_dimensional_cov_matrices_array

--- a/fcest/helpers/inference.py
+++ b/fcest/helpers/inference.py
@@ -1,5 +1,6 @@
 import logging
 
+import gpflow
 from gpflow.monitor import (
     # ImageToTensorBoard,
     ModelToTensorBoard,
@@ -10,8 +11,14 @@ from gpflow.monitor import (
 import tensorflow as tf
 
 
-def run_adam_vwp(
-        model, iterations: int, log_interval: int, log_dir: str = None
+def run_adam(
+    model_type: str,
+    model,
+    iterations: int,
+    log_interval: int,
+    log_dir: str = None,
+    data: tuple = None,
+    train_inducing_variables: bool = True,
 ) -> list:
     """
     GPflow utility function for running the Adam optimizer.
@@ -25,108 +32,72 @@ def run_adam_vwp(
 
     Parameters
     ----------
+    :param model_type:
     :param model:
         GPflow model.
     :param iterations:
         The number of iterations.
     :param log_interval:
     :param log_dir:
-    :return:
-    """
-    # Create an Adam Optimizer action
-    logf = []
-    training_loss = model.training_loss_closure(
-        compile=True
-    )
-    optimizer = tf.optimizers.Adam(
-        learning_rate=0.001
-    )
-
-    # Set up Tensorboard monitoring.
-    if log_dir is not None:
-        model_task = ModelToTensorBoard(log_dir, model)
-        # image_task = ImageToTensorBoard(log_dir, plot_prediction, "image_samples")
-        lml_task = ScalarToTensorBoard(
-            log_dir,
-            lambda: model.training_loss(),
-            "training_objective"
-        )
-
-        # Plotting tasks can be quite slow. We want to run them less frequently.
-        # We group them in a `MonitorTaskGroup` and set the period to 5.
-        # slow_tasks = MonitorTaskGroup(image_task, period=5)
-
-        # The other tasks are fast. We run them at each iteration of the optimisation.
-        fast_tasks = MonitorTaskGroup([model_task, lml_task], period=1)
-
-        # Both groups are passed to the monitor.
-        # `slow_tasks` will be run five times less frequently than `fast_tasks`.
-        # monitor = Monitor(fast_tasks, slow_tasks)
-        monitor = Monitor(fast_tasks)
-
-    @tf.function
-    def optimization_step():
-        optimizer.minimize(training_loss, model.trainable_variables)
-
-    for step in range(iterations):
-        optimization_step()
-        if log_dir is not None:
-            monitor(step)  # run monitoring to Tensorboard
-        if step % log_interval == 0:
-            elbo = -training_loss().numpy()
-            logf.append(elbo)
-    return logf
-
-
-def run_adam_svwp(
-        model, data, iterations: int, log_interval: int, log_dir: str = None
-) -> list:
-    """
-    Utility function running the Adam optimizer.
-
-    TODO: add option for minibatches? merge with above function?
-
-    Parameters
-    ----------
-    :param model:
-        GPflow model.
     :param data:
         A tuple with:
             x_observed: expected in shape (n_time_steps, 1), i.e. (N, 1).
             y_observed: expected in shape (n_time_steps, n_time_series), i.e. (N, D).
-    :param iterations:
-        Number of iterations.
-    :param log_interval:
-    :param log_dir:
-        Directory where to save Tensorboard log files.
+    :param train_inducing_variables:
+        Whether to train inducing variables.
     :return:
     """
+    if not train_inducing_variables:
+        gpflow.set_trainable(model.inducing_variable, False)
+
     # Create an Adam Optimizer action
     logf = []
-    training_loss = model.training_loss_closure(
-        data,
-        compile=True  # compile=True (default): compiles using tf.function
-    )
+    match model_type:
+        case "SVWP":
+            training_loss = model.training_loss_closure(
+                data,
+                compile=True  # compile=True (default): compiles using tf.function
+            )
+        case "VWP":
+            # train_iter = iter(train_dataset.batch(minibatch_size))
+            training_loss = model.training_loss_closure(
+                # train_iter,
+                compile=True,
+            )
+
     optimizer = tf.optimizers.Adam(
         learning_rate=0.001
     )
 
     # Set up Tensorboard monitoring.
     if log_dir is not None:
+
         model_task = ModelToTensorBoard(log_dir, model)
         # image_task = ImageToTensorBoard(log_dir, plot_prediction, "image_samples")
-        lml_task = ScalarToTensorBoard(
-            log_dir,
-            lambda: model.training_loss(data=data),
-            "training_objective"
-        )
+
+        match model_type:
+            case "SVWP":
+                lml_task = ScalarToTensorBoard(
+                    log_dir,
+                    lambda: model.training_loss(data=data),
+                    "training_objective"
+                )
+            case "VWP":
+                lml_task = ScalarToTensorBoard(
+                    log_dir,
+                    lambda: model.training_loss(),
+                    "training_objective"
+                )
 
         # Plotting tasks can be quite slow. We want to run them less frequently.
         # We group them in a `MonitorTaskGroup` and set the period to 5.
         # slow_tasks = MonitorTaskGroup(image_task, period=5)
 
-        # The other tasks are fast. We run them at each iteration of the optimisation.
-        fast_tasks = MonitorTaskGroup([model_task, lml_task], period=1)
+        # The other tasks are fast. We run them at each iteration of the optimization.
+        fast_tasks = MonitorTaskGroup(
+            [model_task, lml_task],
+            period=1
+        )
 
         # Both groups are passed to the monitor.
         # `slow_tasks` will be run five times less frequently than `fast_tasks`.
@@ -135,7 +106,10 @@ def run_adam_svwp(
 
     @tf.function
     def optimization_step():
-        optimizer.minimize(training_loss, model.trainable_variables)
+        optimizer.minimize(
+            training_loss,
+            model.trainable_variables
+        )
 
     for step in range(iterations):
         optimization_step()

--- a/fcest/helpers/inference.py
+++ b/fcest/helpers/inference.py
@@ -19,6 +19,7 @@ def run_adam(
     log_dir: str = None,
     data: tuple = None,
     train_inducing_variables: bool = True,
+    minibatch_size: int = None,
 ) -> list:
     """
     GPflow utility function for running the Adam optimizer.
@@ -49,6 +50,9 @@ def run_adam(
     """
     if not train_inducing_variables:
         gpflow.set_trainable(model.inducing_variable, False)
+
+    if minibatch_size is not None:
+        raise NotImplementedError("Minibatch training is not yet implemented.")
 
     # Create an Adam Optimizer action
     logf = []
@@ -108,7 +112,7 @@ def run_adam(
     def optimization_step():
         optimizer.minimize(
             training_loss,
-            model.trainable_variables
+            model.trainable_variables,
         )
 
     for step in range(iterations):

--- a/fcest/helpers/inference.py
+++ b/fcest/helpers/inference.py
@@ -41,8 +41,8 @@ def run_adam(
     :param log_dir:
     :param data:
         A tuple with:
-            x_observed: expected in shape (n_time_steps, 1), i.e. (N, 1).
-            y_observed: expected in shape (n_time_steps, n_time_series), i.e. (N, D).
+            x_observed: expected in shape (num_time_steps, 1), i.e. (N, 1).
+            y_observed: expected in shape (num_time_steps, num_time_series), i.e. (N, D).
     :param train_inducing_variables:
         Whether to train inducing variables.
     :return:

--- a/fcest/helpers/summary_measures.py
+++ b/fcest/helpers/summary_measures.py
@@ -87,14 +87,14 @@ def compute_rate_of_change(full_covariance_structure: np.array) -> np.array:
     num_time_series = full_covariance_structure.shape[1]  # D
 
     average_rate_of_change = np.zeros(shape=(num_time_series, num_time_series))  # (D, D)
-    n_changes = full_covariance_structure.shape[0] - 1
-    for i_time_step in np.arange(n_changes):
+    num_changes = full_covariance_structure.shape[0] - 1
+    for i_time_step in np.arange(num_changes):
         roc = _rate_of_change(
             current_value=full_covariance_structure[i_time_step+1, :, :],
             previous_value=full_covariance_structure[i_time_step, :, :]
         )
         average_rate_of_change += roc
-    average_rate_of_change /= n_changes
+    average_rate_of_change /= num_changes
     return average_rate_of_change
 
 

--- a/fcest/helpers/summary_measures.py
+++ b/fcest/helpers/summary_measures.py
@@ -51,7 +51,9 @@ def fit_and_extract_ar1_param(full_covariance_structure: np.array) -> np.array:
     Summarize estimated TVFC by taking AR(1) component of each time series.
     Diagonal terms are set to zero at the moment.
     """
-    indices = get_all_lower_triangular_indices_tuples(n_time_series=full_covariance_structure.shape[1])
+    indices = get_all_lower_triangular_indices_tuples(
+        num_time_series=full_covariance_structure.shape[1]
+    )
 
     ar1_coefficients = np.zeros(
         shape=(full_covariance_structure.shape[1], full_covariance_structure.shape[2])
@@ -82,9 +84,9 @@ def compute_rate_of_change(full_covariance_structure: np.array) -> np.array:
     :return:
         array of shape (D, D)
     """
-    n_time_series = full_covariance_structure.shape[1]  # D
+    num_time_series = full_covariance_structure.shape[1]  # D
 
-    average_rate_of_change = np.zeros(shape=(n_time_series, n_time_series))  # (D, D)
+    average_rate_of_change = np.zeros(shape=(num_time_series, num_time_series))  # (D, D)
     n_changes = full_covariance_structure.shape[0] - 1
     for i_time_step in np.arange(n_changes):
         roc = _rate_of_change(

--- a/fcest/models/hidden_markov_models.py
+++ b/fcest/models/hidden_markov_models.py
@@ -31,16 +31,16 @@ class HiddenMarkovModel:
         Parameters
         ----------
         :param x_train_locations:
-            Array of expected shape (n_time_steps, 1), i.e. (N, 1)
+            Array of expected shape (num_time_steps, 1), i.e. (N, 1)
         :param y_train_locations:
-            Array of expected shape (n_time_steps, n_time_series), i.e. (N, D)
+            Array of expected shape (num_time_steps, num_time_series), i.e. (N, D)
         :return:
         """
         self.x_train = x_train_locations
         self.y_train = y_train_locations
         assert len(x_train_locations) == len(y_train_locations)
 
-        self.n_time_steps = y_train_locations.shape[0]  # N
-        self.n_time_series = y_train_locations.shape[1]  # D
+        self.num_time_steps = y_train_locations.shape[0]  # N
+        self.num_time_series = y_train_locations.shape[1]  # D
 
         raise NotImplementedError

--- a/fcest/models/sliding_windows.py
+++ b/fcest/models/sliding_windows.py
@@ -149,11 +149,11 @@ class SlidingWindows:
             y_train = self.y_train
 
         # Pad zeros to time series to be able to compute covariances at the edges.
-        n_zeros_to_pad = int(np.floor(window_length / 2))
+        num_zeros_to_pad = int(np.floor(window_length / 2))
         y_train = np.concatenate((
-            np.zeros((n_zeros_to_pad, num_time_series)),
+            np.zeros((num_zeros_to_pad, num_time_series)),
             y_train,
-            np.zeros((n_zeros_to_pad, num_time_series))
+            np.zeros((num_zeros_to_pad, num_time_series))
         ))
 
         estimated_tvfc = np.zeros((num_time_steps, num_time_series, num_time_series))  # empty covariances array to fill
@@ -205,17 +205,17 @@ class SlidingWindows:
             Should be 2 to make sure the window length is always uneven (and thus symmetrical)
         :param eval_location_step_size:
         :return:
-            DataFrame of shape (n_eval_locations, n_proposed_window_lengths).
+            DataFrame of shape (num_eval_locations, num_proposed_window_lengths).
         """
-        n_evaluation_points = self.num_time_steps - self.maximum_proposal_window_length
+        num_evaluation_points = self.num_time_steps - self.maximum_proposal_window_length
 
         proposal_window_length_range = np.arange(
             self.minimum_proposal_window_length, self.maximum_proposal_window_length,
             window_length_step_size
         )
-        n_proposal_window_lengths = len(proposal_window_length_range)
+        num_proposal_window_lengths = len(proposal_window_length_range)
         proposal_window_length_range_seconds = proposal_window_length_range * self.repetition_time
-        logging.info(f"Proposing {n_proposal_window_lengths:d} window lengths (from {self.minimum_proposal_window_length:d} to {self.maximum_proposal_window_length:d}, in steps of {window_length_step_size:d}).")
+        logging.info(f"Proposing {num_proposal_window_lengths:d} window lengths (from {self.minimum_proposal_window_length:d} to {self.maximum_proposal_window_length:d}, in steps of {window_length_step_size:d}).")
 
         x_eval_location_minimum = int((self.maximum_proposal_window_length - 1) / 2)
         x_eval_location_maximum = self.num_time_steps - int((self.maximum_proposal_window_length + 1) / 2)
@@ -223,8 +223,8 @@ class SlidingWindows:
             x_eval_location_minimum, x_eval_location_maximum,
             eval_location_step_size
         )
-        n_eval_locations = len(eval_locations)
-        logging.info(f"Evaluating on {n_eval_locations:d} observations (from position {x_eval_location_minimum:d} to {x_eval_location_maximum:d}).")
+        num_eval_locations = len(eval_locations)
+        logging.info(f"Evaluating on {num_eval_locations:d} observations (from position {x_eval_location_minimum:d} to {x_eval_location_maximum:d}).")
 
         results_df = pd.DataFrame()
         for proposal_window_length in proposal_window_length_range:

--- a/fcest/models/sliding_windows.py
+++ b/fcest/models/sliding_windows.py
@@ -45,9 +45,9 @@ class SlidingWindows:
         Parameters
         ----------
         :param x_train_locations:
-            Array of expected shape (n_time_steps, 1), i.e. (N, 1)
+            Array of expected shape (num_time_steps, 1), i.e. (N, 1)
         :param y_train_locations:
-            Array of expected shape (n_time_steps, n_time_series), i.e. (N, D)
+            Array of expected shape (num_time_steps, num_time_series), i.e. (N, D)
         :param repetition_time:
             If no repetition time is fed, then we assume we are running on synthetic data.
         :param window_shape:
@@ -57,8 +57,8 @@ class SlidingWindows:
         self.y_train = y_train_locations
         assert len(x_train_locations) == len(y_train_locations)
 
-        self.n_time_steps = y_train_locations.shape[0]  # N
-        self.n_time_series = y_train_locations.shape[1]  # D
+        self.num_time_steps = y_train_locations.shape[0]  # N
+        self.num_time_series = y_train_locations.shape[1]  # D
 
         if repetition_time is None:
             logging.info("No repetition time found, assuming we are running simulations.")
@@ -95,7 +95,7 @@ class SlidingWindows:
                 raise NotImplementedError(f"Connectivity metric {connectivity_metric:s} not recognized.")
         if return_structure:
             sfc_estimate = np.tile(
-                sfc_estimate, reps=(self.n_time_steps, 1, 1)
+                sfc_estimate, reps=(self.num_time_steps, 1, 1)
             )  # (N, D, D)
             assert len(sfc_estimate.shape) == 3
 
@@ -133,15 +133,17 @@ class SlidingWindows:
         :param connectivity_metric:
             Brain region functional connectivity metric, either 'covariance' or 'correlation'.
         :return:
-            TVFC covariance structure array of shape (N, D, D), i.e. (n_time_steps, n_time_series, n_time_series).
+            TVFC covariance structure array of shape (N, D, D), i.e. (num_time_steps, num_time_series, num_time_series).
         """
-        n_time_steps = self.y_train.shape[0]
-        n_time_series = self.y_train.shape[1]
+        num_time_steps = self.y_train.shape[0]
+        num_time_series = self.y_train.shape[1]
 
         # Highpass filtering as recommended by Leonardi2015.
         if repetition_time is not None:
             y_train = highpass_filter_data(
-                self.y_train, window_length=window_length, repetition_time=repetition_time
+                self.y_train,
+                window_length=window_length,
+                repetition_time=repetition_time
             )
         else:
             y_train = self.y_train
@@ -149,13 +151,13 @@ class SlidingWindows:
         # Pad zeros to time series to be able to compute covariances at the edges.
         n_zeros_to_pad = int(np.floor(window_length / 2))
         y_train = np.concatenate((
-            np.zeros((n_zeros_to_pad, n_time_series)),
+            np.zeros((n_zeros_to_pad, num_time_series)),
             y_train,
-            np.zeros((n_zeros_to_pad, n_time_series))
+            np.zeros((n_zeros_to_pad, num_time_series))
         ))
 
-        estimated_tvfc = np.zeros((n_time_steps, n_time_series, n_time_series))  # empty covariances array to fill
-        for i_window in range(int(n_time_steps / step_size)):
+        estimated_tvfc = np.zeros((num_time_steps, num_time_series, num_time_series))  # empty covariances array to fill
+        for i_window in range(int(num_time_steps / step_size)):
             start_index = int(i_window * step_size)
             y_subset_indices = np.arange(start_index, start_index + window_length)
             y_subset = y_train[y_subset_indices, :]
@@ -205,7 +207,7 @@ class SlidingWindows:
         :return:
             DataFrame of shape (n_eval_locations, n_proposed_window_lengths).
         """
-        n_evaluation_points = self.n_time_steps - self.maximum_proposal_window_length
+        n_evaluation_points = self.num_time_steps - self.maximum_proposal_window_length
 
         proposal_window_length_range = np.arange(
             self.minimum_proposal_window_length, self.maximum_proposal_window_length,
@@ -216,7 +218,7 @@ class SlidingWindows:
         logging.info(f"Proposing {n_proposal_window_lengths:d} window lengths (from {self.minimum_proposal_window_length:d} to {self.maximum_proposal_window_length:d}, in steps of {window_length_step_size:d}).")
 
         x_eval_location_minimum = int((self.maximum_proposal_window_length - 1) / 2)
-        x_eval_location_maximum = self.n_time_steps - int((self.maximum_proposal_window_length + 1) / 2)
+        x_eval_location_maximum = self.num_time_steps - int((self.maximum_proposal_window_length + 1) / 2)
         eval_locations = np.arange(
             x_eval_location_minimum, x_eval_location_maximum,
             eval_location_step_size
@@ -238,21 +240,21 @@ class SlidingWindows:
                 # Select testing frame from all observations.
                 y_eval_window = self.y_train[:test_frame_end, :]
                 y_eval_window = y_eval_window[test_frame_start:, :]  # (proposal_window_length, D)
-                assert y_eval_window.shape == (proposal_window_length, self.n_time_series)
+                assert y_eval_window.shape == (proposal_window_length, self.num_time_series)
 
                 # Remove point of interest.
                 new_y_eval_index = int((proposal_window_length - 1) / 2)
                 y_eval_window = np.delete(y_eval_window, new_y_eval_index, axis=0)  # (proposal_window_length - 1, D)
-                assert y_eval_window.shape == (proposal_window_length - 1, self.n_time_series)
+                assert y_eval_window.shape == (proposal_window_length - 1, self.num_time_series)
 
                 # Estimated covariance matrix at this point of interest.
                 cov_matrix_eval_window = np.cov(y_eval_window.T)  # (D, D)
-                assert cov_matrix_eval_window.shape == (self.n_time_series, self.n_time_series)
+                assert cov_matrix_eval_window.shape == (self.num_time_series, self.num_time_series)
 
                 # Compute log likelihood of this observation under this covariance matrix.
                 mvn_logpdf = multivariate_normal.logpdf(
                     x=y_eval_location,
-                    mean=np.zeros(self.n_time_series),
+                    mean=np.zeros(self.num_time_series),
                     cov=cov_matrix_eval_window,
                     allow_singular=True  # TODO: this might be problematic
                 )
@@ -278,7 +280,7 @@ class SlidingWindows:
             # Find minimum and maximum proposal window lengths in number of TRs.
             minimum_proposal_window_length_trs = int(np.ceil(min_proposal_window_length_seconds / self.repetition_time))
             maximum_proposal_window_length_trs = np.minimum(
-                int(np.ceil(self.n_time_steps * self.repetition_time / 2 / self.repetition_time)),
+                int(np.ceil(self.num_time_steps * self.repetition_time / 2 / self.repetition_time)),
                 int(np.ceil(max_proposal_window_length_seconds / self.repetition_time))
             )
 
@@ -291,7 +293,7 @@ class SlidingWindows:
             self.minimum_proposal_window_length = minimum_proposal_window_length_trs
             self.maximum_proposal_window_length = maximum_proposal_window_length_trs
         else:
-            match self.n_time_steps:
+            match self.num_time_steps:
                 case 60:
                     self.minimum_proposal_window_length = 9
                     self.maximum_proposal_window_length = 31
@@ -337,7 +339,7 @@ class SlidingWindows:
 
         return optimal_window_length
 
-    def windowed_cov_estimation(self, n_windows: int) -> np.array:
+    def windowed_cov_estimation(self, num_windows: int) -> np.array:
         """
         Segmented, non-overlapping windows.
 
@@ -347,13 +349,13 @@ class SlidingWindows:
             Number of non-overlapping windows.
             If set to 1, this is the static covariance estimate.
         :return:
-            covariance structure array of shape (N, D, D), i.e. (n_time_steps, n_time_series, n_time_series).
+            covariance structure array of shape (N, D, D), i.e. (num_time_steps, num_time_series, num_time_series).
         """
-        n_time_steps = self.y_train.shape[0]
-        n_time_series = self.y_train.shape[1]
-        cov_structure = np.zeros((n_time_steps, n_time_series, n_time_series))
-        window_length = n_time_steps / n_windows
-        for i_window in range(n_windows):
+        num_time_steps = self.y_train.shape[0]
+        num_time_series = self.y_train.shape[1]
+        cov_structure = np.zeros((num_time_steps, num_time_series, num_time_series))
+        window_length = num_time_steps / num_windows
+        for i_window in range(num_windows):
             y_subset_indices = np.arange(int(i_window * window_length), int((i_window + 1) * window_length))
             y_subset = self.y_train[y_subset_indices, :]
             cov_structure[y_subset_indices, :, :] = np.cov(y_subset.T)  # np.cov() accepts multivariate inputs

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/OnnoKampman/FCEst',
     packages=packages,
     install_requires=[
-        'gpflow==2.6.0',
+        'gpflow==2.6.1',
         'numpy',
         'pandas==1.5.3',
         'rpy2==3.4.5',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/OnnoKampman/FCEst',
     packages=packages,
     install_requires=[
-        'gpflow==2.6.1',
+        'gpflow>=2.6.0',
         'numpy',
         'pandas==1.5.3',
         'rpy2==3.4.5',

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ setup(
     install_requires=[
         'gpflow==2.5.2',
         'numpy',
-        'pandas',
+        'pandas==1.5.3',
         'rpy2==3.4.5',
         'scipy',
         'statsmodels',
-        'tensorflow',
+        'tensorflow>=2.10',
     ],
     python_requires='>=3.10',
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/OnnoKampman/FCEst',
     packages=packages,
     install_requires=[
-        'gpflow==2.5.2',
+        'gpflow==2.6.0',
         'numpy',
         'pandas==1.5.3',
         'rpy2==3.4.5',

--- a/tests/fcest/models/test_likelihoods.py
+++ b/tests/fcest/models/test_likelihoods.py
@@ -20,13 +20,15 @@ class TestLikelihoods(unittest.TestCase):
     """
 
     def test_tensor_computations(
-            self, n_mc_samples: int = 2, num_time_steps: int = 6, 
+            self, num_mc_samples: int = 2, num_time_steps: int = 6, 
             num_time_series: int = 2, nu: int = 3
-    ):
+    ) -> None:
         """
+        Test tensor computations.
+
         Parameters
         ----------
-        :param n_mc_samples:
+        :param num_mc_samples:
             Number of MC samples (S).
         :param num_time_steps:
             Number of time steps (N).
@@ -34,7 +36,6 @@ class TestLikelihoods(unittest.TestCase):
             Number of time series (D).
         :param nu:
             Degrees of freedom.
-        :return:
         """
         A = 2 * np.eye(2)
         A[0, 1] = A[1, 0] = -0.1
@@ -42,7 +43,7 @@ class TestLikelihoods(unittest.TestCase):
         y_data = np.ones((num_time_steps, num_time_series))
 
         f_sample = np.random.random(size=(num_time_steps, num_time_series, nu))
-        f_sample = np.tile(f_sample[None, :, :, :], [n_mc_samples, 1, 1, 1])
+        f_sample = np.tile(f_sample[None, :, :, :], [num_mc_samples, 1, 1, 1])
         f_sample = tf.Variable(f_sample)
 
         af = tf.matmul(A, f_sample)
@@ -66,16 +67,17 @@ class TestLikelihoods(unittest.TestCase):
         # Test different ways to compute the same tensor.
         yaffay_1 = tf.matmul(yaffa_1, y_data, transpose_b=True)
         yaffay_1 = tf.math.reduce_mean(yaffay_1, axis=2)
-        y_data_tiled = tf.tile(y_data[None, :, :, None], [n_mc_samples, 1, 1, 1])  # (S, N, D, 1)
+        y_data_tiled = tf.tile(y_data[None, :, :, None], [num_mc_samples, 1, 1, 1])  # (S, N, D, 1)
         L_solve_y = tf.linalg.triangular_solve(L, y_data_tiled, lower=True)
         yaffay_2 = tf.math.reduce_sum(L_solve_y ** 2, axis=(2, 3))
         assert_array_almost_equal(yaffay_1, yaffay_2)
 
     def test_wishart_process_likelihood(self):
+
         wishart_process_likelihood = WishartProcessLikelihood(
             D=2,
             nu=2,
-            n_mc_samples=7,
+            num_mc_samples=7,
             A_scale_matrix_option='train_full_matrix',
             train_additive_noise=True
         )

--- a/tests/fcest/models/test_likelihoods.py
+++ b/tests/fcest/models/test_likelihoods.py
@@ -20,17 +20,17 @@ class TestLikelihoods(unittest.TestCase):
     """
 
     def test_tensor_computations(
-            self, n_mc_samples: int = 2, n_time_steps: int = 6, 
-            n_time_series: int = 2, nu: int = 3
+            self, n_mc_samples: int = 2, num_time_steps: int = 6, 
+            num_time_series: int = 2, nu: int = 3
     ):
         """
         Parameters
         ----------
         :param n_mc_samples:
             Number of MC samples (S).
-        :param n_time_steps:
+        :param num_time_steps:
             Number of time steps (N).
-        :param n_time_series:
+        :param num_time_series:
             Number of time series (D).
         :param nu:
             Degrees of freedom.
@@ -39,9 +39,9 @@ class TestLikelihoods(unittest.TestCase):
         A = 2 * np.eye(2)
         A[0, 1] = A[1, 0] = -0.1
         A = tf.Variable(A)
-        y_data = np.ones((n_time_steps, n_time_series))
+        y_data = np.ones((num_time_steps, num_time_series))
 
-        f_sample = np.random.random(size=(n_time_steps, n_time_series, nu))
+        f_sample = np.random.random(size=(num_time_steps, num_time_series, nu))
         f_sample = np.tile(f_sample[None, :, :, :], [n_mc_samples, 1, 1, 1])
         f_sample = tf.Variable(f_sample)
 

--- a/tests/fcest/models/test_mgarch.py
+++ b/tests/fcest/models/test_mgarch.py
@@ -42,11 +42,11 @@ class TestMGARCH(unittest.TestCase):
 
     @staticmethod
     def _get_dummy_training_data(
-        n_time_series: int = 2, n_time_steps: int = 400
+        num_time_series: int = 2, num_time_steps: int = 400
     ) -> pd.DataFrame:
         np.random.seed(2023)
         return pd.DataFrame(
-            np.random.normal(size=(n_time_steps, n_time_series))
+            np.random.normal(size=(num_time_steps, num_time_series))
         )
 
 

--- a/tests/fcest/models/test_sliding_windows.py
+++ b/tests/fcest/models/test_sliding_windows.py
@@ -24,8 +24,8 @@ class TestSlidingWindows(unittest.TestCase):
             [1, 1],
             [2, 0]
         ])  # (N, D)
-        n_time_steps = y_test.shape[0]
-        x_test = np.linspace(0, 1, n_time_steps)
+        num_time_steps = y_test.shape[0]
+        x_test = np.linspace(0, 1, num_time_steps)
         sliding_windows = SlidingWindows(
             x_train_locations=x_test,
             y_train_locations=y_test
@@ -37,7 +37,7 @@ class TestSlidingWindows(unittest.TestCase):
             [1., -1.],
             [-1., 1.]
         ])
-        true_cov = np.tile(true_cov, reps=(n_time_steps, 1, 1))
+        true_cov = np.tile(true_cov, reps=(num_time_steps, 1, 1))
         assert_array_equal(cov_estimates, true_cov)
 
     def test_static_correlation_estimate_bivariate(self):
@@ -46,8 +46,8 @@ class TestSlidingWindows(unittest.TestCase):
             [1, 1],
             [2, 0]
         ])  # (N, D)
-        n_time_steps = y_test.shape[0]
-        x_test = np.linspace(0, 1, n_time_steps)
+        num_time_steps = y_test.shape[0]
+        x_test = np.linspace(0, 1, num_time_steps)
         sliding_windows = SlidingWindows(
             x_train_locations=x_test,
             y_train_locations=y_test
@@ -59,7 +59,7 @@ class TestSlidingWindows(unittest.TestCase):
             [1., -1.],
             [-1., 1.]
         ])
-        true_corr = np.tile(true_corr, reps=(n_time_steps, 1, 1))
+        true_corr = np.tile(true_corr, reps=(num_time_steps, 1, 1))
         assert_array_equal(corr_estimates, true_corr)
 
     def test_static_covariance_estimate_trivariate(self):
@@ -68,8 +68,8 @@ class TestSlidingWindows(unittest.TestCase):
             [1, 1, 1],
             [2, 0, 0]
         ])  # (N, D)
-        n_time_steps = y_test.shape[0]
-        x_test = np.linspace(0, 1, n_time_steps)
+        num_time_steps = y_test.shape[0]
+        x_test = np.linspace(0, 1, num_time_steps)
         sliding_windows = SlidingWindows(
             x_train_locations=x_test,
             y_train_locations=y_test
@@ -82,7 +82,7 @@ class TestSlidingWindows(unittest.TestCase):
             [-1., 1., 1.],
             [-1., 1., 1.]
         ])
-        true_cov = np.tile(true_cov, (n_time_steps, 1, 1))
+        true_cov = np.tile(true_cov, (num_time_steps, 1, 1))
         assert_array_equal(cov_estimates, true_cov)
 
 

--- a/tests/fcest/models/test_wishart_process.py
+++ b/tests/fcest/models/test_wishart_process.py
@@ -2,7 +2,7 @@ import logging
 import unittest
 
 import gpflow
-from gpflow.ci_utils import ci_niter
+from gpflow.ci_utils import reduce_in_tests
 import numpy as np
 
 from fcest.helpers.inference import run_adam
@@ -45,7 +45,7 @@ class TestWishartProcess(unittest.TestCase):
             kernel=k,
         )
 
-        maxiter = ci_niter(num_iterations)
+        maxiter = reduce_in_tests(num_iterations)
         logf = run_adam(
             model_type="SVWP",
             model=m,
@@ -75,7 +75,7 @@ class TestWishartProcess(unittest.TestCase):
             kernel=k,
         )
 
-        maxiter = ci_niter(num_iterations)
+        maxiter = reduce_in_tests(num_iterations)
         logf = run_adam(
             model_type="VWP",
             model=m,

--- a/tests/fcest/models/test_wishart_process.py
+++ b/tests/fcest/models/test_wishart_process.py
@@ -5,7 +5,7 @@ import gpflow
 from gpflow.ci_utils import ci_niter
 import numpy as np
 
-from fcest.helpers.inference import run_adam_svwp, run_adam_vwp
+from fcest.helpers.inference import run_adam
 from fcest.models.wishart_process import SparseVariationalWishartProcess, VariationalWishartProcess
 
 logging.basicConfig(
@@ -42,7 +42,8 @@ class TestWishartProcess(unittest.TestCase):
             kernel=k,
         )
         maxiter = ci_niter(3)
-        # logf = run_adam_svwp(
+        # logf = run_adam(
+        #     "SVWP",
         #     m,
         #     data=(x, y),
         #     iterations=maxiter,
@@ -64,7 +65,8 @@ class TestWishartProcess(unittest.TestCase):
             kernel=k,
         )
         maxiter = ci_niter(3)
-        logf = run_adam_vwp(
+        logf = run_adam(
+            "VWP",
             m,
             iterations=maxiter,
             log_interval=100,

--- a/tests/fcest/models/test_wishart_process.py
+++ b/tests/fcest/models/test_wishart_process.py
@@ -17,17 +17,6 @@ logging.basicConfig(
 
 class TestWishartProcess(unittest.TestCase):
 
-    @staticmethod
-    def _generate_dummy_data() -> (np.array, np.array):
-
-        num_time_series = 2
-        num_time_steps = 7
-
-        x = np.linspace(0, 1, num_time_steps).reshape(-1, 1)
-        y = np.random.random(size=(num_time_steps, num_time_series))
-
-        return x, y
-
     def test_sparse_variational_wishart_process(
         self,
         num_iterations: int = 3,
@@ -86,6 +75,19 @@ class TestWishartProcess(unittest.TestCase):
 
         self.assertEqual(type(logf), list)
         self.assertEqual(len(logf), maxiter)
+
+    @staticmethod
+    def _generate_dummy_data() -> (np.array, np.array):
+        """
+        Generate dummy data for testing.
+        """
+        num_time_series = 2
+        num_time_steps = 7
+
+        x = np.linspace(0, 1, num_time_steps).reshape(-1, 1)
+        y = np.random.random(size=(num_time_steps, num_time_series))
+
+        return x, y
 
 
 if __name__ == "__main__":

--- a/tests/fcest/models/test_wishart_process.py
+++ b/tests/fcest/models/test_wishart_process.py
@@ -31,7 +31,7 @@ class TestWishartProcess(unittest.TestCase):
     def test_sparse_variational_wishart_process(
         self,
         num_iterations: int = 3,
-    ):
+    ) -> None:
         """
         Test instantiation of SparseVariationalWishartProcess.
         """
@@ -51,7 +51,7 @@ class TestWishartProcess(unittest.TestCase):
             model=m,
             data=(x, y),
             iterations=maxiter,
-            log_interval=100,
+            log_interval=1,
             log_dir=None,
         )
 
@@ -61,7 +61,7 @@ class TestWishartProcess(unittest.TestCase):
     def test_variational_wishart_process(
         self,
         num_iterations: int = 3,
-    ):
+    ) -> None:
         """
         Test instantiation of VariationalWishartProcess.
         """
@@ -80,7 +80,7 @@ class TestWishartProcess(unittest.TestCase):
             model_type="VWP",
             model=m,
             iterations=maxiter,
-            log_interval=100,
+            log_interval=1,
             log_dir=None,
         )
 

--- a/tests/fcest/models/test_wishart_process.py
+++ b/tests/fcest/models/test_wishart_process.py
@@ -40,7 +40,7 @@ class TestWishartProcess(unittest.TestCase):
         k = gpflow.kernels.Matern52()
         m = SparseVariationalWishartProcess(
             D=y.shape[1],
-            Z=np.arange(y.shape[0]),
+            Z=np.arange(y.shape[0]).reshape(-1, 1),
             nu=y.shape[1],
             kernel=k,
         )

--- a/tests/fcest/models/test_wishart_process.py
+++ b/tests/fcest/models/test_wishart_process.py
@@ -20,15 +20,18 @@ class TestWishartProcess(unittest.TestCase):
     @staticmethod
     def _generate_dummy_data() -> (np.array, np.array):
 
-        n_time_series = 2
-        n_time_steps = 7
+        num_time_series = 2
+        num_time_steps = 7
 
-        x = np.linspace(0, 1, n_time_steps).reshape(-1, 1)
-        y = np.random.random(size=(n_time_steps, n_time_series))
+        x = np.linspace(0, 1, num_time_steps).reshape(-1, 1)
+        y = np.random.random(size=(num_time_steps, num_time_series))
 
         return x, y
 
-    def test_sparse_variational_wishart_process(self):
+    def test_sparse_variational_wishart_process(
+        self,
+        num_iterations: int = 3,
+    ):
         """
         Test instantiation of SparseVariationalWishartProcess.
         """
@@ -41,17 +44,24 @@ class TestWishartProcess(unittest.TestCase):
             nu=y.shape[1],
             kernel=k,
         )
-        maxiter = ci_niter(3)
-        # logf = run_adam(
-        #     "SVWP",
-        #     m,
-        #     data=(x, y),
-        #     iterations=maxiter,
-        #     log_interval=100,
-        #     log_dir=None,
-        # )
 
-    def test_variational_wishart_process(self):
+        maxiter = ci_niter(num_iterations)
+        logf = run_adam(
+            model_type="SVWP",
+            model=m,
+            data=(x, y),
+            iterations=maxiter,
+            log_interval=100,
+            log_dir=None,
+        )
+
+        self.assertEqual(type(logf), list)
+        self.assertEqual(len(logf), maxiter)
+
+    def test_variational_wishart_process(
+        self,
+        num_iterations: int = 3,
+    ):
         """
         Test instantiation of VariationalWishartProcess.
         """
@@ -64,14 +74,18 @@ class TestWishartProcess(unittest.TestCase):
             nu=y.shape[1],
             kernel=k,
         )
-        maxiter = ci_niter(3)
+
+        maxiter = ci_niter(num_iterations)
         logf = run_adam(
-            "VWP",
-            m,
+            model_type="VWP",
+            model=m,
             iterations=maxiter,
             log_interval=100,
             log_dir=None,
         )
+
+        self.assertEqual(type(logf), list)
+        self.assertEqual(len(logf), maxiter)
 
 
 if __name__ == "__main__":

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,4 +1,4 @@
-gpflow==2.6.1
+gpflow>=2.6.0
 # mpfr  # for installing R package 'rmgarch' on Ubuntu
 numpy
 pandas==1.5.3

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,4 +1,4 @@
-gpflow==2.6.0
+gpflow==2.6.1
 # mpfr  # for installing R package 'rmgarch' on Ubuntu
 numpy
 pandas==1.5.3

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,4 +1,4 @@
-gpflow==2.5.2
+gpflow==2.6.0
 # mpfr  # for installing R package 'rmgarch' on Ubuntu
 numpy
 pandas==1.5.3
@@ -11,4 +11,4 @@ rpy2==3.4.5
 scikit-learn
 scipy
 statsmodels
-tensorflow
+tensorflow>=2.10


### PR DESCRIPTION
GPflow introduced some breaking changes for us in release 2.6.0.

The core of these changes are in `gpflow.likelihoods.base.py`.

https://github.com/GPflow/GPflow/releases/tag/v2.6.0

This pull request adopts to code to these changes, which makes FCEst version beyond 0.1.0 incompatible with GPflow versions before 2.6.0.

## Changes

* Function `ci_niter` has been renamed `reduce_in_tests`
* The Likelihood class now requires an additional `input_dim` argument
* All likelihood methods require an additional `X` argument now